### PR TITLE
fix for the change of closure archive structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ closure-compiler:
 		&& tar -xf "./tmp/compiler-latest.tgz" -C "./tmp/closure-compiler"
 # Move compiler.jar
 	mkdir "closure-compiler"
-	mv "./tmp/closure-compiler/compiler.jar" "./closure-compiler/"
+	mv ./tmp/closure-compiler/closure-compiler-*.jar "./closure-compiler/compiler.jar"
 # Cleanup
 	rm -fr "tmp"
 


### PR DESCRIPTION
This is hot fix for https://github.com/teppeis/fast-closure-compiler2/pull/3.

Using the official npm package `google-closure-compiler` is better, but it requires to run JS with Node to get the path to the compiler.jar.
So just extend glob, instead of using the package.

@denji please review and merge this, and I will publish new version.