### PR TITLE
Use the compiler provided by google-closure-compiler, if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,23 @@ bin/$(OUTFILE):
 	cd "bin" && javac "NailgunTest.java" && gcc "NailgunTest.c" -shared -o $(OUTFILE) $(CCFLAGS)
 
 closure-compiler:
-# Init bootstraping
+	mkdir "closure-compiler"
+
+# Use the compiler provide by google-closure-compiler, if available
+ifneq ("$(wildcard ../google-closure-compiler/compiler.jar)","")
+	cp "../google-closure-compiler/compiler.jar" "./closure-compiler/compiler.jar"
+
+else
+# Else, init bootstraping
 	rm -fr "tmp"; mkdir -p "tmp/closure-compiler"
 # Download latest Google Closure Compiler
 	curl -L -o "./tmp/compiler-latest.tgz" "https://dl.google.com/closure-compiler/compiler-latest.tar.gz" \
 		&& tar -xf "./tmp/compiler-latest.tgz" -C "./tmp/closure-compiler"
 # Move compiler.jar
-	mkdir "closure-compiler"
 	mv ./tmp/closure-compiler/closure-compiler-*.jar "./closure-compiler/compiler.jar"
 # Cleanup
 	rm -fr "tmp"
+endif
 
 nailgun:
 # Init bootstraping

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   },
   "scripts": {
     "install": "make install"
+  },
+  "peerDependencies": {
+    "google-closure-compiler": ">=20160822.1.0"
   }
 }


### PR DESCRIPTION
Opening this PR because I believe https://github.com/closure-gun/closure-gun/pull/2 has not fixed the issue.

Currently, the Makefile will always download the latest version it can find, even if the library consumer already has the npm dependency google-closure-compiler installed.
This leads to the problem that they cannot lock down what version gets used, leading to different version across development, staging, testing and production environments.
This PR updates the Makefile so that it first checks for the compiler provided by google-closure-compiler and if that fails (google-closure-compiler is not installed or has renamed the filename) it will download the latest version for convenience.

We could also think about removing the download step entirely and making google-closure-compiler a hard dependency of this library. This would pass the control to the shrinkwrap or yarn lockfile.